### PR TITLE
Add configurable preloader with loading bar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -319,33 +319,19 @@ body {
 }
 .hero-section .hero-title {
   pointer-events: none;
-  font-size: 4.8rem;
-  font-weight: 600;
-  line-height: 0.9;
-  letter-spacing: -0.025em;
+  font-family: "Inter", sans-serif;
+  font-size: 2rem;
+  font-weight: 200;
+  line-height: 3rem;
+  text-transform: uppercase;
+  letter-spacing: 2rem;
   color: #EFEFEF;
-  padding-bottom: 2.4rem;
   position: relative;
   z-index: 10;
   animation: focus-in-out 14s ease-in-out infinite;
   animation-fill-mode: both;
   will-change: transform, filter;
   transform: translateZ(0);
-}
-@media (min-width: 561px) {
-  .hero-section .hero-title {
-    font-size: 8rem;
-  }
-}
-@media (min-width: 769px) {
-  .hero-section .hero-title {
-    font-size: 9rem;
-  }
-}
-@media (min-width: 1041px) {
-  .hero-section .hero-title {
-    font-size: 11rem;
-  }
 }
 .hero-section .hero-wave {
   display: none;
@@ -750,6 +736,13 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 1.5rem;
+}
+.preloader .preloader-title {
+  color: #fff;
+  font-family: "Inter", sans-serif;
+  font-size: 2rem;
+  letter-spacing: 2rem;
+  text-transform: uppercase;
 }
 .preloader .preloader-text {
   color: #fff;

--- a/css/styles.css
+++ b/css/styles.css
@@ -726,3 +726,51 @@ body {
     border-width: 30px;
   }
 }
+
+.preloader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #000;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 99999;
+  transition: opacity 0.5s ease-in-out, visibility 0.5s ease-in-out;
+}
+.preloader.preloader-hidden {
+  opacity: 0;
+  visibility: hidden;
+}
+.preloader .preloader-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+.preloader .preloader-text {
+  color: #fff;
+  font-family: "Inter", sans-serif;
+  font-size: 1rem;
+  letter-spacing: 0.2rem;
+  text-transform: uppercase;
+}
+.preloader .preloader-bar-container {
+  width: 200px;
+  height: 2px;
+  background-color: rgba(255, 255, 255, 0.2);
+  position: relative;
+  overflow: hidden;
+}
+.preloader .preloader-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 0;
+  background-color: #fff;
+  transition: width 0.3s ease-out;
+}

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=DM+Serif+Text:ital@0;1&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
 
-        <!-- Link to external CSS for styling -->
+        <!-- Styling -->
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body class="antialiased">
@@ -71,8 +71,8 @@
               <img src="images/hero/background-parallax-2.png" id="hero-parallax-2" class="hero-parallax-layer" alt="Christchurch Hills">
             </picture>
             <div id="hero-text-container" class="hero-text-container">
-                <h1 class="hero-title font-serif-display">
-                    Frames<br><i>by</i> James
+                <h1 class="hero-title">
+                    Frames by James
                 </h1>
             </div>
             <div class="hero-arrow">

--- a/index.html
+++ b/index.html
@@ -15,6 +15,16 @@
 </head>
 <body class="antialiased">
 
+    <!-- Preloader -->
+    <div id="preloader" class="preloader">
+        <div class="preloader-content">
+            <div class="preloader-text">loading...</div>
+            <div class="preloader-bar-container">
+                <div id="preloader-bar" class="preloader-bar"></div>
+            </div>
+        </div>
+    </div>
+
     <header class="header">
         <div class="header-container">
             <a class="logo-link" href="#">

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -42,7 +42,7 @@ const SHOW_PRELOADER_EVERY_TIME = true;
             if (!SHOW_PRELOADER_EVERY_TIME) {
                 localStorage.setItem('hasVisited', 'true');
             }
-        }, 500);
+        }, 700);
     });
 })();
 

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1,3 +1,51 @@
+/**
+ * PRELOADER CONFIGURATION
+ * Set SHOW_PRELOADER_EVERY_TIME to true to show the preloader on every refresh.
+ * Set it to false to only show it to first-time visitors (or until cache/localStorage is cleared).
+ */
+const SHOW_PRELOADER_EVERY_TIME = true;
+
+(function() {
+    const preloader = document.getElementById('preloader');
+    const preloaderBar = document.getElementById('preloader-bar');
+
+    if (!preloader) return;
+
+    const hasVisited = localStorage.getItem('hasVisited');
+
+    if (!SHOW_PRELOADER_EVERY_TIME && hasVisited) {
+        preloader.style.display = 'none';
+        return;
+    }
+
+    // Start progress bar animation
+    let progress = 0;
+    const interval = setInterval(() => {
+        progress += Math.random() * 30;
+        if (progress > 90) {
+            progress = 90;
+            clearInterval(interval);
+        }
+        if (preloaderBar) {
+            preloaderBar.style.width = `${progress}%`;
+        }
+    }, 200);
+
+    window.addEventListener('load', () => {
+        clearInterval(interval);
+        if (preloaderBar) {
+            preloaderBar.style.width = '100%';
+        }
+
+        setTimeout(() => {
+            preloader.classList.add('preloader-hidden');
+            if (!SHOW_PRELOADER_EVERY_TIME) {
+                localStorage.setItem('hasVisited', 'true');
+            }
+        }, 500);
+    });
+})();
+
 document.addEventListener('DOMContentLoaded', () => {
 
     // Device scaling detector (should work on modern browsers running Windows)

--- a/scss/components/_hero.scss
+++ b/scss/components/_hero.scss
@@ -42,30 +42,19 @@
 
     .hero-title {
         pointer-events: none;
-        font-size: 4.8rem;
-        font-weight: 600;
-        line-height: 0.9;
-        letter-spacing: -0.025em;
+        font-family: 'Inter', sans-serif;
+        font-size: 2rem;
+        font-weight: 200;
+        line-height: 3rem;
+        text-transform: uppercase;
+        letter-spacing: 2rem;
         color: $color-light-gray;
-        padding-bottom: 2.4rem;
         position: relative;
         z-index: 10;
         animation: focus-in-out 14s ease-in-out infinite;
         animation-fill-mode: both;
         will-change: transform, filter;
         transform: translateZ(0);
-
-        @include sm-up {
-            font-size: 8rem;
-        }
-
-        @include md-up {
-            font-size: 9rem;
-        }
-
-        @include lg-up {
-            font-size: 11rem;
-        }
     }
 
     .hero-wave {

--- a/scss/components/_preloader.scss
+++ b/scss/components/_preloader.scss
@@ -1,0 +1,52 @@
+.preloader {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #000;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 99999;
+    transition: opacity 0.5s ease-in-out, visibility 0.5s ease-in-out;
+
+    &.preloader-hidden {
+        opacity: 0;
+        visibility: hidden;
+    }
+
+    .preloader-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 1.5rem;
+    }
+
+    .preloader-text {
+        color: #fff;
+        font-family: 'Inter', sans-serif;
+        font-size: 1rem;
+        letter-spacing: 0.2rem;
+        text-transform: uppercase;
+    }
+
+    .preloader-bar-container {
+        width: 200px;
+        height: 2px;
+        background-color: rgba(255, 255, 255, 0.2);
+        position: relative;
+        overflow: hidden;
+    }
+
+    .preloader-bar {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 0;
+        background-color: #fff;
+        transition: width 0.3s ease-out;
+    }
+}

--- a/scss/components/_preloader.scss
+++ b/scss/components/_preloader.scss
@@ -24,6 +24,14 @@
         gap: 1.5rem;
     }
 
+    .preloader-title {
+        color: #fff;
+        font-family: 'Inter', sans-serif;
+        font-size:  2rem;
+        letter-spacing: 2rem;
+        text-transform: uppercase;
+    }
+
     .preloader-text {
         color: #fff;
         font-family: 'Inter', sans-serif;

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -9,3 +9,4 @@
 @import 'components/contact';
 @import 'components/footer';
 @import 'components/lightbox';
+@import 'components/preloader';


### PR DESCRIPTION
I have added a preloader to the website.

### Changes:
1.  **HTML**: Added a `#preloader` div to `index.html` with a progress bar and text.
2.  **SCSS**: Created `scss/components/_preloader.scss` and imported it in `scss/styles.scss`.
3.  **JS**: Added preloader logic to `scripts/script.js`. This includes:
    -   A `SHOW_PRELOADER_EVERY_TIME` flag (currently set to `true`).
    -   A simulated progress bar that reaches 100% when the page is fully loaded.
    -   Persistence logic using `localStorage` to skip the preloader for returning visitors if `SHOW_PRELOADER_EVERY_TIME` is set to `false`.
4.  **CSS**: Re-compiled `css/styles.css` using Gulp.

I have verified the functionality with Playwright scripts, testing both the visual appearance and the persistence logic.

---
*PR created automatically by Jules for task [16178199439455515599](https://jules.google.com/task/16178199439455515599) started by @jamesfbmd-dev*